### PR TITLE
add typo catch validation for lamda vs lambda

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -35,6 +35,9 @@ function validate( opts, options ) {
 			return new TypeError( 'cdf()::invalid option. `lambda` parameter must be a positive number. Option: `' + opts.lambda + '`.' );
 		}
 	}
+	if ( options.hasOwnProperty( 'lamda' ) ) {
+		return new TypeError( 'cdf()::invalid option. `lamda`, did you mean, `lambda` ? );' )
+	}
 	if ( options.hasOwnProperty( 'copy' ) ) {
 		opts.copy = options.copy;
 		if ( !isBoolean( opts.copy ) ) {


### PR DESCRIPTION
- added a validation to catch the typo difference between lambda and lamda. I was accidentally using the latter, not throwing and err and having it instead default to 1 made me think it was working. I think it'd be better to throw an error 

'lamda' is a legitimate alternative spelling of 'lambda' (see link), not that I advocate for it :) 
https://books.google.com/books?id=UgvLBQAAQBAJ&pg=PA198&lpg=PA198&dq=lamda+numerical+computation&source=bl&ots=sg9WOkA5MP&sig=sF8YCTApmfiWw_BM6Clbrkpd0Tg&hl=en&sa=X&ved=0ahUKEwj4hMeHy8DJAhVSpYMKHfKHAX0Q6AEIJzAC#v=onepage&q=lamda%20numerical%20computation&f=false
